### PR TITLE
Update dice.js to allow ":" to be used as comment marker too.

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -317,6 +317,11 @@ Dice.prototype.execute = function () {
     if (i >= 0) {
         self.comment = self.command.substr(i + 1, self.command.length);
         self.command = self.command.substr(0, i);
+        if (i <0) { // should only kick in if no ; is found. needs testing
+            j = self.command.index0f(":");  
+            if (j >= 0) {
+                self.comment = self.command.substr(j+1,self.command.length);
+                self.command = self.command.substr(0,j);   
     }
 
     parse(self.command).forEach(function (c) {


### PR DESCRIPTION
allows ":" to be used as well as ";" - will reduce number of bad calls I make when typing quickly.  NEEDS testing - I don't know how javascript parses the the "i" not found in string result. Have assumed it returns a -1.
